### PR TITLE
Update addon_config.mk to enable msys2 build

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -69,7 +69,7 @@ common:
 
     ADDON_LIBS_EXCLUDE = libs/OpenVR/samples/%
     ADDON_LIBS_EXCLUDE += libs/OpenVR/unity_package/%
-    ADDON_LIBS_EXCLUDE += libs/OpenVR/bin/%
+    #ADDON_LIBS_EXCLUDE += libs/OpenVR/bin/%
 
 	ADDON_SOURCES_EXCLUDE = libs/OpenVR/samples/%
     ADDON_SOURCES_EXCLUDE += MX/%

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -29,7 +29,7 @@ common:
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be
 	# specified here separated by spaces or one per line using +=
-	ADDON_INCLUDES = libs/OpenVR/headers src/ libs/OpenVR/src/ libs/OpenVR/src/vrcommon/
+	ADDON_INCLUDES = libs/OpenVR/headers libs/OpenVR/src/ libs/OpenVR/src/vrcommon/ src/
 	
 	
 	# any special flag that should be passed to the compiler when using this
@@ -98,7 +98,7 @@ linux:
     ADDON_CFLAGS = -DPOSIX -DLINUX
 
 msys2:
-	ADDON_CFLAGS = -DVR_API_PUBLIC
+	#ADDON_CFLAGS = 
 
 osx:
 	ADDON_CFLAGS = -DPOSIX -DOSX

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -94,7 +94,7 @@ vs:
 linux64:
 #    ADDON_SOURCES_EXCLUDE = libs/OpenVR/samples/%
 #    ADDON_SOURCES_EXCLUDE += libs/OpenVR/unity_package/%
-    ADDON_CFLAGS = -DPOSIX -DLINUX -DLINUX64
+	ADDON_CFLAGS = -DPOSIX -DLINUX -DLINUX64
 linux:
 	ADDON_CFLAGS = -DPOSIX -DLINUX
 

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -100,7 +100,7 @@ linux:
 
 msys2:
 	#ADDON_CFLAGS = 
-	ADDON_LDFLAGS = -L ../../../libs/OpenVR/bin/win32/ -lopenvr_api
+	ADDON_LDFLAGS = -L${OF_ROOT}/addons/ofxOpenVRTracker/libs/OpenVR/bin/win32/ -lopenvr_api
 
 osx:
 	ADDON_CFLAGS = -DPOSIX -DOSX

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -67,36 +67,36 @@ common:
 	ADDON_INCLUDES_EXCLUDE += libs/OpenVR/samples/%
 	ADDON_INCLUDES_EXCLUDE += libs/OpenVR/unity_package/%
 
-    ADDON_LIBS_EXCLUDE = libs/OpenVR/samples/%
-    ADDON_LIBS_EXCLUDE += libs/OpenVR/unity_package/%
-    #ADDON_LIBS_EXCLUDE += libs/OpenVR/bin/%
+	ADDON_LIBS_EXCLUDE = libs/OpenVR/samples/%
+	ADDON_LIBS_EXCLUDE += libs/OpenVR/unity_package/%
+	#ADDON_LIBS_EXCLUDE += libs/OpenVR/bin/%
 
 	ADDON_SOURCES_EXCLUDE = libs/OpenVR/samples/%
-    ADDON_SOURCES_EXCLUDE += MX/%
+	ADDON_SOURCES_EXCLUDE += MX/%
 
 vs:
-    ADDON_INCLUDES_EXCLUDE = ..\..\..\addons\ofxOpenVR\libs
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin\%
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin\%
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib\%
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib\%
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples\%
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\unity_package
-    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\unity_package\%
+	ADDON_INCLUDES_EXCLUDE = ..\..\..\addons\ofxOpenVR\libs
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin\%
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin\%
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib\%
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib\%
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples\%
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\unity_package
+	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\unity_package\%
 
-    ADDON_SOURCES_EXCLUDE = ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples
-    ADDON_SOURCES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples\%
+	ADDON_SOURCES_EXCLUDE = ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples
+	ADDON_SOURCES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples\%
 
 linux64:
 #    ADDON_SOURCES_EXCLUDE = libs/OpenVR/samples/%
 #    ADDON_SOURCES_EXCLUDE += libs/OpenVR/unity_package/%
     ADDON_CFLAGS = -DPOSIX -DLINUX -DLINUX64
 linux:
-    ADDON_CFLAGS = -DPOSIX -DLINUX
+	ADDON_CFLAGS = -DPOSIX -DLINUX
 
 msys2:
 	#ADDON_CFLAGS = 

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -29,15 +29,16 @@ common:
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be
 	# specified here separated by spaces or one per line using +=
-	# ADDON_INCLUDES =
+	ADDON_INCLUDES = libs/OpenVR/headers src/ libs/OpenVR/src/ libs/OpenVR/src/vrcommon/
+	
 	
 	# any special flag that should be passed to the compiler when using this
 	# addon
-	# ADDON_CFLAGS =
+	ADDON_CFLAGS = -DPOSIX -DOSX
 	
 	# any special flag that should be passed to the linker when using this
 	# addon, also used for system libraries with -lname
-	ADDON_LDFLAGS = -lopenvr_api
+	#ADDON_LDFLAGS = -lopenvr_api
 	
 	# linux only, any library that should be included in the project using
 	# pkg-config
@@ -60,19 +61,38 @@ common:
 	# a specific platform
 	# ADDON_LIBS_EXCLUDE =
 
-	ADDON_INCLUDES_EXCLUDE = ..\..\..\addons\ofxOpenVR\libs
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin\%
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin\%
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib\%
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib\%
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples\%
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\unity_package
-	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\unity_package\%
+	ADDON_INCLUDES_EXCLUDE = libs/OpenVR/bin/
+	ADDON_INCLUDES_EXCLUDE += libs/OpenVR/bin/%
+	ADDON_INCLUDES_EXCLUDE += libs/OpenVR/lib/%
+	ADDON_INCLUDES_EXCLUDE += libs/OpenVR/samples/%
+	ADDON_INCLUDES_EXCLUDE += libs/OpenVR/unity_package/%
 
-	ADDON_SOURCES_EXCLUDE = ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples
-	ADDON_SOURCES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples\%
-	
+    ADDON_LIBS_EXCLUDE = libs/OpenVR/samples/%
+    ADDON_LIBS_EXCLUDE += libs/OpenVR/unity_package/%
+
+	ADDON_SOURCES_EXCLUDE = libs/OpenVR/samples/%
+    ADDON_SOURCES_EXCLUDE += MX/%
+
+vs:
+    ADDON_INCLUDES_EXCLUDE = ..\..\..\addons\ofxOpenVR\libs
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin\%
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin\%
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib\%
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\lib\%
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples\%
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\unity_package
+    ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\unity_package\%
+
+    ADDON_SOURCES_EXCLUDE = ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples
+    ADDON_SOURCES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\samples\%
+
+linux64:
+#    ADDON_SOURCES_EXCLUDE = libs/OpenVR/samples/%
+#    ADDON_SOURCES_EXCLUDE += libs/OpenVR/unity_package/%
+    ADDON_CFLAGS = -DPOSIX -DLINUX
+linux:
+    ADDON_CFLAGS = -DPOSIX -DLINUX

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -37,7 +37,7 @@ common:
 	
 	# any special flag that should be passed to the linker when using this
 	# addon, also used for system libraries with -lname
-	# ADDON_LDFLAGS =
+	ADDON_LDFLAGS = -lopenvr_api
 	
 	# linux only, any library that should be included in the project using
 	# pkg-config
@@ -60,7 +60,6 @@ common:
 	# a specific platform
 	# ADDON_LIBS_EXCLUDE =
 
-vs:
 	ADDON_INCLUDES_EXCLUDE = ..\..\..\addons\ofxOpenVR\libs
 	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR
 	ADDON_INCLUDES_EXCLUDE += ..\..\..\addons\ofxOpenVR\libs\OpenVR\bin

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -29,7 +29,7 @@ common:
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be
 	# specified here separated by spaces or one per line using +=
-	ADDON_INCLUDES = libs/OpenVR/headers libs/OpenVR/src/ libs/OpenVR/src/vrcommon/ src/
+	ADDON_INCLUDES = src/ libs/OpenVR/headers libs/OpenVR/src/ libs/OpenVR/src/vrcommon/
 	
 	
 	# any special flag that should be passed to the compiler when using this
@@ -69,6 +69,7 @@ common:
 
     ADDON_LIBS_EXCLUDE = libs/OpenVR/samples/%
     ADDON_LIBS_EXCLUDE += libs/OpenVR/unity_package/%
+    ADDON_LIBS_EXCLUDE += libs/OpenVR/bin/%
 
 	ADDON_SOURCES_EXCLUDE = libs/OpenVR/samples/%
     ADDON_SOURCES_EXCLUDE += MX/%

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -34,7 +34,7 @@ common:
 	
 	# any special flag that should be passed to the compiler when using this
 	# addon
-	ADDON_CFLAGS = -DPOSIX -DOSX
+	#ADDON_CFLAGS = -DPOSIX -DOSX
 	
 	# any special flag that should be passed to the linker when using this
 	# addon, also used for system libraries with -lname
@@ -93,6 +93,12 @@ vs:
 linux64:
 #    ADDON_SOURCES_EXCLUDE = libs/OpenVR/samples/%
 #    ADDON_SOURCES_EXCLUDE += libs/OpenVR/unity_package/%
-    ADDON_CFLAGS = -DPOSIX -DLINUX
+    ADDON_CFLAGS = -DPOSIX -DLINUX -DLINUX64
 linux:
     ADDON_CFLAGS = -DPOSIX -DLINUX
+
+msys2:
+	ADDON_CFLAGS = -DVR_API_PUBLIC
+
+osx:
+	ADDON_CFLAGS = -DPOSIX -DOSX

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -100,6 +100,7 @@ linux:
 
 msys2:
 	#ADDON_CFLAGS = 
+	ADDON_LDFLAGS = -L ../../../libs/OpenVR/bin/win32/ -lopenvr_api
 
 osx:
 	ADDON_CFLAGS = -DPOSIX -DOSX


### PR DESCRIPTION
The addon works fine on msys2 build environment with these small changes. You'll need openvr libs installed through pacman.

The vs vars are needed for msys2 as well so I reckon these are common.